### PR TITLE
#95 Searchbar always centered

### DIFF
--- a/components/Navbar/index.tsx
+++ b/components/Navbar/index.tsx
@@ -13,6 +13,7 @@ import {
   NavBarButtons,
   NavbarWrapper,
   MenuIcon,
+  RightSideNav,
 } from "./styled";
 import WhiteLogo from "~/assets/img/white-logo.svg";
 
@@ -75,7 +76,7 @@ const Navbar = () => {
             ))}
           </NavBarButtons>
         ) : (
-          <NavBarButtons>
+          <RightSideNav>
             <MenuIcon
               onClick={() => setOpenMenu(!openMenu)}
               openMenu={openMenu}
@@ -85,7 +86,7 @@ const Navbar = () => {
               <span></span>
               <span></span>
             </MenuIcon>
-          </NavBarButtons>
+          </RightSideNav>
         )}
 
         <Sidebar menuOpen={openMenu} closeMenu={() => setOpenMenu(false)} />

--- a/components/Navbar/styled.ts
+++ b/components/Navbar/styled.ts
@@ -37,6 +37,12 @@ export const NavBarButtons = styled.div`
   }
 `;
 
+export const RightSideNav = styled.div`
+  display: flex;
+  flex: 1;
+  justify-content: flex-end;
+`;
+
 export const MenuIcon = styled.div<MenuIconProps>`
   width: 2rem;
   height: 2rem;


### PR DESCRIPTION
I think flex 1 will solve the bug

logo and navbarbutton: flex 1
searchbar: flex 2

without searchbar, logo and navbarbutton will take half each
![DeepinScreenshot_select-area_20210406173348](https://user-images.githubusercontent.com/58845052/113690960-8c9ea980-96fe-11eb-94c1-ce3ff24f0548.png)

with searchbar, navbar width will devide into 3 with searchbar width is much longer because of  flex 2
![DeepinScreenshot_select-area_20210406173502](https://user-images.githubusercontent.com/58845052/113691044-a3450080-96fe-11eb-9fc1-2a45019ea850.png)
